### PR TITLE
vnext

### DIFF
--- a/QueryFramework.sln
+++ b/QueryFramework.sln
@@ -36,8 +36,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QueryFramework.FileSystemSe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QueryFramework.CodeGeneration", "src\QueryFramework.CodeGeneration\QueryFramework.CodeGeneration.csproj", "{D4CE70D5-6BB1-4B62-8184-657A748782C6}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionFramework.Domain2", "..\ExpressionFramework\src\ExpressionFramework.Domain2\ExpressionFramework.Domain2.csproj", "{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -96,10 +94,6 @@ Global
 		{D4CE70D5-6BB1-4B62-8184-657A748782C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4CE70D5-6BB1-4B62-8184-657A748782C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D4CE70D5-6BB1-4B62-8184-657A748782C6}.Release|Any CPU.Build.0 = Release|Any CPU
-		{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/QueryFramework.sln
+++ b/QueryFramework.sln
@@ -36,6 +36,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QueryFramework.FileSystemSe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QueryFramework.CodeGeneration", "src\QueryFramework.CodeGeneration\QueryFramework.CodeGeneration.csproj", "{D4CE70D5-6BB1-4B62-8184-657A748782C6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExpressionFramework.Domain2", "..\ExpressionFramework\src\ExpressionFramework.Domain2\ExpressionFramework.Domain2.csproj", "{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -94,6 +96,10 @@ Global
 		{D4CE70D5-6BB1-4B62-8184-657A748782C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D4CE70D5-6BB1-4B62-8184-657A748782C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D4CE70D5-6BB1-4B62-8184-657A748782C6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{13C2BBE2-8302-4473-8D36-89C91E1BFB9C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/QueryFramework.Abstractions/ComposableEvaluatableBuilderHelper.cs
+++ b/src/QueryFramework.Abstractions/ComposableEvaluatableBuilderHelper.cs
@@ -11,12 +11,30 @@ public static class ComposableEvaluatableBuilderHelper
             .WithStartGroup(startGroup)
             .WithEndGroup(endGroup);
 
+    public static ComposableEvaluatableBuilder Create(string fieldName, OperatorBuilder @operator, ExpressionBuilder rightExpression, Combination? combination = null, bool startGroup = false, bool endGroup = false, ExpressionBuilder? expression = null)
+        => new ComposableEvaluatableBuilder()
+            .WithCombination(combination)
+            .WithLeftExpression(expression ?? new FieldExpressionBuilder().WithExpression(new ContextExpressionBuilder()).WithFieldName(fieldName))
+            .WithOperator(@operator)
+            .WithRightExpression(rightExpression)
+            .WithStartGroup(startGroup)
+            .WithEndGroup(endGroup);
+
     public static ComposableEvaluatableBuilder Create(ExpressionBuilder leftExpression, OperatorBuilder @operator, object? value, Combination? combination = null, bool startGroup = false, bool endGroup = false)
         => new ComposableEvaluatableBuilder()
             .WithCombination(combination)
             .WithLeftExpression(leftExpression)
             .WithOperator(@operator)
             .WithRightExpression(new ConstantExpressionBuilder().WithValue(value))
+            .WithStartGroup(startGroup)
+            .WithEndGroup(endGroup);
+
+    public static ComposableEvaluatableBuilder Create(ExpressionBuilder leftExpression, OperatorBuilder @operator, ExpressionBuilder rightExpression, Combination? combination = null, bool startGroup = false, bool endGroup = false)
+        => new ComposableEvaluatableBuilder()
+            .WithCombination(combination)
+            .WithLeftExpression(leftExpression)
+            .WithOperator(@operator)
+            .WithRightExpression(rightExpression)
             .WithStartGroup(startGroup)
             .WithEndGroup(endGroup);
 

--- a/src/QueryFramework.Abstractions/ComposableEvaluatableBuilderHelper.cs
+++ b/src/QueryFramework.Abstractions/ComposableEvaluatableBuilderHelper.cs
@@ -29,7 +29,7 @@ public static class ComposableEvaluatableBuilderHelper
             .WithStartGroup(startGroup)
             .WithEndGroup(endGroup);
 
-    public static ComposableEvaluatableBuilder Create(ExpressionBuilder leftExpression, OperatorBuilder @operator, Combination? combination = null, bool startGroup = false, bool endGroup = false, ExpressionBuilder? expression = null)
+    public static ComposableEvaluatableBuilder Create(ExpressionBuilder leftExpression, OperatorBuilder @operator, Combination? combination = null, bool startGroup = false, bool endGroup = false)
         => new ComposableEvaluatableBuilder()
             .WithCombination(combination)
             .WithLeftExpression(leftExpression)

--- a/src/QueryFramework.Abstractions/ComposableEvaluatableBuilderHelper.cs
+++ b/src/QueryFramework.Abstractions/ComposableEvaluatableBuilderHelper.cs
@@ -2,7 +2,7 @@
 
 public static class ComposableEvaluatableBuilderHelper
 {
-    public static ComposableEvaluatableBuilder Create(string fieldName, OperatorBuilder @operator, object? value, Combination? combination = null, bool? startGroup = null, bool? endGroup = null, ExpressionBuilder? expression = null)
+    public static ComposableEvaluatableBuilder Create(string fieldName, OperatorBuilder @operator, object? value, Combination? combination = null, bool startGroup = false, bool endGroup = false, ExpressionBuilder? expression = null)
         => new ComposableEvaluatableBuilder()
             .WithCombination(combination)
             .WithLeftExpression(expression ?? new FieldExpressionBuilder().WithExpression(new ContextExpressionBuilder()).WithFieldName(fieldName))
@@ -11,7 +11,7 @@ public static class ComposableEvaluatableBuilderHelper
             .WithStartGroup(startGroup)
             .WithEndGroup(endGroup);
 
-    public static ComposableEvaluatableBuilder Create(ExpressionBuilder leftExpression, OperatorBuilder @operator, object? value, Combination? combination = null, bool? startGroup = null, bool? endGroup = null)
+    public static ComposableEvaluatableBuilder Create(ExpressionBuilder leftExpression, OperatorBuilder @operator, object? value, Combination? combination = null, bool startGroup = false, bool endGroup = false)
         => new ComposableEvaluatableBuilder()
             .WithCombination(combination)
             .WithLeftExpression(leftExpression)
@@ -20,7 +20,7 @@ public static class ComposableEvaluatableBuilderHelper
             .WithStartGroup(startGroup)
             .WithEndGroup(endGroup);
 
-    public static ComposableEvaluatableBuilder Create(string fieldName, OperatorBuilder @operator, Combination? combination = null, bool? startGroup = null, bool? endGroup = null, ExpressionBuilder? expression = null)
+    public static ComposableEvaluatableBuilder Create(string fieldName, OperatorBuilder @operator, Combination? combination = null, bool startGroup = false, bool endGroup = false, ExpressionBuilder? expression = null)
         => new ComposableEvaluatableBuilder()
             .WithCombination(combination)
             .WithLeftExpression(expression ?? new FieldExpressionBuilder().WithExpression(new ContextExpressionBuilder()).WithFieldName(fieldName))
@@ -29,7 +29,7 @@ public static class ComposableEvaluatableBuilderHelper
             .WithStartGroup(startGroup)
             .WithEndGroup(endGroup);
 
-    public static ComposableEvaluatableBuilder Create(ExpressionBuilder leftExpression, OperatorBuilder @operator, Combination? combination = null, bool? startGroup = null, bool? endGroup = null, ExpressionBuilder? expression = null)
+    public static ComposableEvaluatableBuilder Create(ExpressionBuilder leftExpression, OperatorBuilder @operator, Combination? combination = null, bool startGroup = false, bool endGroup = false, ExpressionBuilder? expression = null)
         => new ComposableEvaluatableBuilder()
             .WithCombination(combination)
             .WithLeftExpression(leftExpression)

--- a/src/QueryFramework.Abstractions/ComposableEvaluatableBuilderWrapper.cs
+++ b/src/QueryFramework.Abstractions/ComposableEvaluatableBuilderWrapper.cs
@@ -17,20 +17,37 @@ public class ComposableEvaluatableBuilderWrapper<T> where T : IQueryBuilder
     }
 
     #region Generated code
-    public T Contains(object? value)
+    public T Contains(string value)
         => AddFilterWithOperator(new StringContainsOperatorBuilder(), value);
 
-    public T EndsWith(object? value)
+    public T Contains<TExpression>(TExpression expression)
+        where TExpression : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => AddFilterWithOperator(new StringContainsOperatorBuilder(), expression);
+
+    public T EndsWith(string value)
         => AddFilterWithOperator(new EndsWithOperatorBuilder(), value);
+
+    public T EndsWith<TExpression>(TExpression expression)
+        where TExpression : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => AddFilterWithOperator(new EndsWithOperatorBuilder(), expression);
 
     public T IsEqualTo(object? value)
         => AddFilterWithOperator(new EqualsOperatorBuilder(), value);
 
+    public T IsEqualTo(ExpressionBuilder expression)
+        => AddFilterWithOperator(new EqualsOperatorBuilder(), expression);
+
     public T IsGreaterOrEqualThan(object? value)
         => AddFilterWithOperator(new IsGreaterOrEqualOperatorBuilder(), value);
 
+    public T IsGreaterOrEqualThan(ExpressionBuilder expression)
+        => AddFilterWithOperator(new IsGreaterOrEqualOperatorBuilder(), expression);
+
     public T IsGreaterThan(object? value)
         => AddFilterWithOperator(new IsGreaterOperatorBuilder(), value);
+
+    public T IsGreaterThan(ExpressionBuilder expression)
+        => AddFilterWithOperator(new IsGreaterOperatorBuilder(), expression);
 
     public T IsNotNull()
         => AddFilterWithOperator(new IsNotNullOperatorBuilder());
@@ -53,23 +70,48 @@ public class ComposableEvaluatableBuilderWrapper<T> where T : IQueryBuilder
     public T IsSmallerOrEqualThan(object? value)
         => AddFilterWithOperator(new IsSmallerOrEqualOperatorBuilder(), value);
 
+    public T IsSmallerOrEqualThan(ExpressionBuilder expression)
+        => AddFilterWithOperator(new IsSmallerOrEqualOperatorBuilder(), expression);
+
     public T IsSmallerThan(object? value)
         => AddFilterWithOperator(new IsSmallerOperatorBuilder(), value);
 
-    public T DoesNotContain(object? value)
+    public T IsSmallerThan(ExpressionBuilder expression)
+        => AddFilterWithOperator(new IsSmallerOperatorBuilder(), expression);
+
+    public T DoesNotContain(string value)
         => AddFilterWithOperator(new StringNotContainsOperatorBuilder(), value);
 
-    public T DoesNotEndWith(object? value)
+    public T DoesNotContain<TExpression>(TExpression expression)
+        where TExpression : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => AddFilterWithOperator(new StringNotContainsOperatorBuilder(), expression);
+
+    public T DoesNotEndWith(string value)
         => AddFilterWithOperator(new NotEndsWithOperatorBuilder(), value);
+
+    public T DoesNotEndWith<TExpression>(TExpression expression)
+        where TExpression : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => AddFilterWithOperator(new NotEndsWithOperatorBuilder(), expression);
 
     public T IsNotEqualTo(object? value)
         => AddFilterWithOperator(new NotEqualsOperatorBuilder(), value);
 
-    public T DoesNotStartWith(object? value)
+    public T IsNotEqualTo(ExpressionBuilder expression)
+        => AddFilterWithOperator(new NotEqualsOperatorBuilder(), expression);
+
+    public T DoesNotStartWith(string value)
         => AddFilterWithOperator(new NotStartsWithOperatorBuilder(), value);
 
-    public T StartsWith(object? value)
+    public T DoesNotStartWith<TExpression>(TExpression expression)
+        where TExpression : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => AddFilterWithOperator(new NotStartsWithOperatorBuilder(), expression);
+
+    public T StartsWith(string value)
         => AddFilterWithOperator(new StartsWithOperatorBuilder(), value);
+
+    public T StartsWith<TExpression>(TExpression expression)
+        where TExpression : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => AddFilterWithOperator(new StartsWithOperatorBuilder(), expression);
     #endregion
 
     #region Built-in functions
@@ -155,6 +197,9 @@ public class ComposableEvaluatableBuilderWrapper<T> where T : IQueryBuilder
 
     private T AddFilterWithOperator(OperatorBuilder @operator, object? value)
         => _instance.Where(ComposableEvaluatableBuilderHelper.Create(_fieldName, @operator, value, _combination, _startGroup, _endGroup, _expression));
+
+    private T AddFilterWithOperator(OperatorBuilder @operator, ExpressionBuilder expression)
+        => _instance.Where(ComposableEvaluatableBuilderHelper.Create(_fieldName, @operator, expression, _combination, _startGroup, _endGroup, _expression));
 
     private T AddFilterWithOperator(OperatorBuilder @operator)
         => _instance.Where(ComposableEvaluatableBuilderHelper.Create(_fieldName, @operator, _combination, _startGroup, _endGroup, _expression));

--- a/src/QueryFramework.Abstractions/Extensions/ExpressionBuilderExtensions.cs
+++ b/src/QueryFramework.Abstractions/Extensions/ExpressionBuilderExtensions.cs
@@ -17,11 +17,25 @@ public static class ExpressionBuilderExtensions
     public static ComposableEvaluatableBuilder Contains(this ExpressionBuilder instance, string value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new StringContainsOperatorBuilder(), value);
 
+    /// <summary>Creates a query condition builder with the Contains query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder Contains<T>(this ExpressionBuilder instance, T expression)
+        where T : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => ComposableEvaluatableBuilderHelper.Create(instance, new StringContainsOperatorBuilder(), expression);
+
     /// <summary>Creates a query condition builder with the EndsWith query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
     /// <param name="value">The value.</param>
     public static ComposableEvaluatableBuilder EndsWith(this ExpressionBuilder instance, string value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new EndsWithOperatorBuilder(), value);
+
+    /// <summary>Creates a query condition builder with the EndsWith query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder EndsWith<T>(this ExpressionBuilder instance, T expression)
+        where T : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => ComposableEvaluatableBuilderHelper.Create(instance, new EndsWithOperatorBuilder(), expression);
 
     /// <summary>Creates a query condition builder with the Equals query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
@@ -29,17 +43,35 @@ public static class ExpressionBuilderExtensions
     public static ComposableEvaluatableBuilder IsEqualTo(this ExpressionBuilder instance, object? value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new EqualsOperatorBuilder(), value);
 
+    /// <summary>Creates a query condition builder with the Equals query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder IsEqualTo(this ExpressionBuilder instance, ExpressionBuilder expression)
+        => ComposableEvaluatableBuilderHelper.Create(instance, new EqualsOperatorBuilder(), expression);
+
     /// <summary>Creates a query condition builder with the GreaterOrEqualThan query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
     /// <param name="value">The value.</param>
     public static ComposableEvaluatableBuilder IsGreaterOrEqualThan(this ExpressionBuilder instance, object? value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new IsGreaterOrEqualOperatorBuilder(), value);
 
+    /// <summary>Creates a query condition builder with the GreaterOrEqualThan query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder IsGreaterOrEqualThan(this ExpressionBuilder instance, ExpressionBuilder expression)
+        => ComposableEvaluatableBuilderHelper.Create(instance, new IsGreaterOrEqualOperatorBuilder(), expression);
+
     /// <summary>Creates a query condition builder with the GreaterThan query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
     /// <param name="value">The value.</param>
-    public static ComposableEvaluatableBuilder IsGreaterThan(this ExpressionBuilder instance, object? value = null)
+    public static ComposableEvaluatableBuilder IsGreaterThan(this ExpressionBuilder instance, object? value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new IsGreaterOperatorBuilder(), value);
+
+    /// <summary>Creates a query condition builder with the GreaterThan query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder IsGreaterThan(this ExpressionBuilder instance, ExpressionBuilder expression)
+        => ComposableEvaluatableBuilderHelper.Create(instance, new IsGreaterOperatorBuilder(), expression);
 
     /// <summary>Creates a query condition builder with the IsNotNull query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
@@ -77,11 +109,23 @@ public static class ExpressionBuilderExtensions
     public static ComposableEvaluatableBuilder IsSmallerOrEqualThan(this ExpressionBuilder instance, object? value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new IsSmallerOrEqualOperatorBuilder(), value);
 
+    /// <summary>Creates a query condition builder with the LowerOrEqualThan query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder IsSmallerOrEqualThan(this ExpressionBuilder instance, ExpressionBuilder expression)
+        => ComposableEvaluatableBuilderHelper.Create(instance, new IsSmallerOrEqualOperatorBuilder(), expression);
+
     /// <summary>Creates a query condition builder with the LowerTHan query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
     /// <param name="value">The value.</param>
     public static ComposableEvaluatableBuilder IsSmallerThan(this ExpressionBuilder instance, object? value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new IsSmallerOperatorBuilder(), value);
+
+    /// <summary>Creates a query condition builder with the LowerTHan query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder IsSmallerThan(this ExpressionBuilder instance, ExpressionBuilder expression)
+        => ComposableEvaluatableBuilderHelper.Create(instance, new IsSmallerOperatorBuilder(), expression);
 
     /// <summary>Creates a query condition builder with the NotContains query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
@@ -89,23 +133,37 @@ public static class ExpressionBuilderExtensions
     public static ComposableEvaluatableBuilder DoesNotContain(this ExpressionBuilder instance, string value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new StringNotContainsOperatorBuilder(), value);
 
+    /// <summary>Creates a query condition builder with the NotContains query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder DoesNotContain<T>(this ExpressionBuilder instance, T expression)
+        where T : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => ComposableEvaluatableBuilderHelper.Create(instance, new StringNotContainsOperatorBuilder(), expression);
+
     /// <summary>Creates a query condition builder with the NotEndsWith query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
     /// <param name="value">The value.</param>
-    /// <param name="openBracket">if set to <c>true</c> [open bracket].</param>
-    /// <param name="closeBracket">if set to <c>true</c> [close bracket].</param>
-    /// <param name="combination">The combination.</param>
     public static ComposableEvaluatableBuilder DoesNotEndWith(this ExpressionBuilder instance, string value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new NotEndsWithOperatorBuilder(), value);
+
+    /// <summary>Creates a query condition builder with the NotEndsWith query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder DoesNotEndWith<T>(this ExpressionBuilder instance, T expression)
+        where T : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => ComposableEvaluatableBuilderHelper.Create(instance, new NotEndsWithOperatorBuilder(), expression);
 
     /// <summary>Creates a query condition builder with the NotEqual query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
     /// <param name="value">The value.</param>
-    /// <param name="openBracket">if set to <c>true</c> [open bracket].</param>
-    /// <param name="closeBracket">if set to <c>true</c> [close bracket].</param>
-    /// <param name="combination">The combination.</param>
     public static ComposableEvaluatableBuilder IsNotEqualTo(this ExpressionBuilder instance, object? value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new NotEqualsOperatorBuilder(), value);
+
+    /// <summary>Creates a query condition builder with the NotEqual query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder IsNotEqualTo(this ExpressionBuilder instance, ExpressionBuilder expression)
+        => ComposableEvaluatableBuilderHelper.Create(instance, new NotEqualsOperatorBuilder(), expression);
 
     /// <summary>Creates a query condition builder with the NotStartsWith query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
@@ -113,14 +171,25 @@ public static class ExpressionBuilderExtensions
     public static ComposableEvaluatableBuilder DoesNotStartWith(this ExpressionBuilder instance, string value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new NotStartsWithOperatorBuilder(), value);
 
+    /// <summary>Creates a query condition builder with the NotStartsWith query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder DoesNotStartWith<T>(this ExpressionBuilder instance, T expression)
+        where T : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => ComposableEvaluatableBuilderHelper.Create(instance, new NotStartsWithOperatorBuilder(), expression);
+
     /// <summary>Creates a query condition builder with the StartsWith query operator, using the specified values.</summary>
     /// <param name="instance">The query expression builder instance.</param>
     /// <param name="value">The value.</param>
-    /// <param name="openBracket">if set to <c>true</c> [open bracket].</param>
-    /// <param name="closeBracket">if set to <c>true</c> [close bracket].</param>
-    /// <param name="combination">The combination.</param>
     public static ComposableEvaluatableBuilder StartsWith(this ExpressionBuilder instance, string value)
         => ComposableEvaluatableBuilderHelper.Create(instance, new StartsWithOperatorBuilder(), value);
+
+    /// <summary>Creates a query condition builder with the StartsWith query operator, using the specified values.</summary>
+    /// <param name="instance">The query expression builder instance.</param>
+    /// <param name="expression">The expression for the right part of the operator.</param>
+    public static ComposableEvaluatableBuilder StartsWith<T>(this ExpressionBuilder instance, T expression)
+        where T : ExpressionBuilder, ITypedExpressionBuilder<string>
+        => ComposableEvaluatableBuilderHelper.Create(instance, new StartsWithOperatorBuilder(), expression);
     #endregion
 
     #region Built-in functions

--- a/src/QueryFramework.Abstractions/Extensions/QueryBuilderExtensions.cs
+++ b/src/QueryFramework.Abstractions/Extensions/QueryBuilderExtensions.cs
@@ -104,7 +104,7 @@ public static class QueryBuilderExtensions
 
     private sealed class QuerySortOrderBuilder : IQuerySortOrderBuilder
     {
-        public ExpressionBuilder FieldNameExpression { get; set; } = default!;
+        [Required, ValidateObject] public ExpressionBuilder FieldNameExpression { get; set; } = default!;
         public QuerySortOrderDirection Order { get; set; }
 
         public IQuerySortOrder Build() => new QuerySortOrder(FieldNameExpression?.Build(), Order);

--- a/src/QueryFramework.Abstractions/Extensions/QueryBuilderExtensions.cs
+++ b/src/QueryFramework.Abstractions/Extensions/QueryBuilderExtensions.cs
@@ -124,7 +124,7 @@ public static class QueryBuilderExtensions
         public IQuerySortOrderBuilder ToBuilder()
             => new QuerySortOrderBuilder
             {
-                FieldNameExpression = ExpressionBuilderFactory.Create(FieldNameExpression),
+                FieldNameExpression = FieldNameExpression.ToBuilder(),
                 Order = Order
             };
     }

--- a/src/QueryFramework.Abstractions/GlobalUsings.cs
+++ b/src/QueryFramework.Abstractions/GlobalUsings.cs
@@ -4,6 +4,7 @@ global using System.Collections.Generic;
 global using System.ComponentModel.DataAnnotations;
 global using System.Linq;
 global using CrossCutting.Common;
+global using CrossCutting.Common.DataAnnotations;
 global using CrossCutting.Common.Extensions;
 global using CrossCutting.Data.Abstractions;
 global using ExpressionFramework.Domain;

--- a/src/QueryFramework.Abstractions/QueryFramework.Abstractions.csproj
+++ b/src/QueryFramework.Abstractions/QueryFramework.Abstractions.csproj
@@ -11,8 +11,7 @@
   <ItemGroup>
     <PackageReference Include="pauldeen79.CrossCutting.Common" Version="3.9.0" />
     <PackageReference Include="pauldeen79.CrossCutting.Data.Abstractions" Version="2.10.0" />
-    <PackageReference Include="pauldeen79.ExpressionFramework.Domain" Version="0.6.3" />
-    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Builders" Version="0.6.3" />
+    <PackageReference Include="pauldeen79.ExpressionFramework.Domain" Version="0.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/QueryFramework.Abstractions/QueryFramework.Abstractions.csproj
+++ b/src/QueryFramework.Abstractions/QueryFramework.Abstractions.csproj
@@ -11,14 +11,12 @@
   <ItemGroup>
     <PackageReference Include="pauldeen79.CrossCutting.Common" Version="3.9.0" />
     <PackageReference Include="pauldeen79.CrossCutting.Data.Abstractions" Version="2.10.0" />
+    <PackageReference Include="pauldeen79.ExpressionFramework.Domain" Version="0.6.3" />
+    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Builders" Version="0.6.3" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Builders\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\ExpressionFramework\src\ExpressionFramework.Domain2\ExpressionFramework.Domain2.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/QueryFramework.Abstractions/QueryFramework.Abstractions.csproj
+++ b/src/QueryFramework.Abstractions/QueryFramework.Abstractions.csproj
@@ -11,12 +11,14 @@
   <ItemGroup>
     <PackageReference Include="pauldeen79.CrossCutting.Common" Version="3.9.0" />
     <PackageReference Include="pauldeen79.CrossCutting.Data.Abstractions" Version="2.10.0" />
-    <PackageReference Include="pauldeen79.ExpressionFramework.Domain" Version="0.6.3" />
-    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Builders" Version="0.6.3" />
   </ItemGroup>
 
   <ItemGroup>
     <Folder Include="Builders\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\ExpressionFramework\src\ExpressionFramework.Domain2\ExpressionFramework.Domain2.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/QueryFramework.CodeGeneration/CodeGenerationProviders/QueryFrameworkCSharpClassBase.cs
+++ b/src/QueryFramework.CodeGeneration/CodeGenerationProviders/QueryFrameworkCSharpClassBase.cs
@@ -48,9 +48,9 @@ public abstract class QueryFrameworkCSharpClassBase : CsharpClassGeneratorPipeli
                 (
                     new MetadataBuilder().WithValue(typeof(ExpressionBuilder).Namespace).WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderNamespace),
                     new MetadataBuilder().WithValue(TypeNameDotClassNameBuilder).WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderName),
-                    new MetadataBuilder().WithValue($"{typeof(ExpressionBuilderFactory).FullName}.Create(source.[Name])").WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderConstructorInitializeExpression),
-                    new MetadataBuilder().WithValue(new Literal($"default({typeof(ExpressionBuilder).FullName})", null)).WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderDefaultValue),
-                    new MetadataBuilder().WithValue($"[Name][NullableSuffix].Build()").WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderMethodParameterExpression)
+                    new MetadataBuilder().WithValue("[Name][NullableSuffix].ToBuilder()[ForcedNullableSuffix]").WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderSourceExpression),
+                    new MetadataBuilder().WithValue("[Name][NullableSuffix].Build()[ForcedNullableSuffix]").WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderMethodParameterExpression),
+                    new MetadataBuilder().WithValue(new Literal($"default({typeof(ExpressionBuilder).FullName})", null)).WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderDefaultValue)
                 ),
         }.Concat(
             GetType().Assembly.GetTypes()
@@ -70,8 +70,8 @@ public abstract class QueryFrameworkCSharpClassBase : CsharpClassGeneratorPipeli
                                 new MetadataBuilder().WithValue(TypeNameDotClassNameBuilder).WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderName),
                                 new MetadataBuilder().WithValue($"{ProjectName}.Abstractions.Builders").WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderInterfaceNamespace),
                                 new MetadataBuilder().WithValue(TypeNameDotClassNameBuilder).WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderInterfaceName),
-                                new MetadataBuilder().WithValue("[Name][NullableSuffix].ToBuilder()").WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderSourceExpression),
-                                new MetadataBuilder().WithValue("[Name][NullableSuffix].Build()").WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderMethodParameterExpression),
+                                new MetadataBuilder().WithValue("[Name][NullableSuffix].ToBuilder()[ForcedNullableSuffix]").WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderSourceExpression),
+                                new MetadataBuilder().WithValue("[Name][NullableSuffix].Build()[ForcedNullableSuffix]").WithName(ClassFramework.Pipelines.MetadataNames.CustomBuilderMethodParameterExpression),
                                 new MetadataBuilder().WithName(ClassFramework.Pipelines.MetadataNames.CustomEntityInterfaceTypeName).WithValue($"{ProjectName}.Abstractions.I{x.GetEntityClassName()}")
                             )
                     })

--- a/src/QueryFramework.CodeGeneration/QueryFramework.CodeGeneration.csproj
+++ b/src/QueryFramework.CodeGeneration/QueryFramework.CodeGeneration.csproj
@@ -12,9 +12,11 @@
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.10.0" />
-    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Builders" Version="0.6.3" />
-    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Specialized" Version="0.6.3" />
     <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="0.9.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\ExpressionFramework\src\ExpressionFramework.Domain2\ExpressionFramework.Domain2.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/QueryFramework.CodeGeneration/QueryFramework.CodeGeneration.csproj
+++ b/src/QueryFramework.CodeGeneration/QueryFramework.CodeGeneration.csproj
@@ -12,11 +12,9 @@
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.10.0" />
+    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Builders" Version="0.6.3" />
+    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Specialized" Version="0.6.3" />
     <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="0.9.3" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\ExpressionFramework\src\ExpressionFramework.Domain2\ExpressionFramework.Domain2.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/QueryFramework.CodeGeneration/QueryFramework.CodeGeneration.csproj
+++ b/src/QueryFramework.CodeGeneration/QueryFramework.CodeGeneration.csproj
@@ -12,8 +12,7 @@
     <PackageReference Include="CsharpExpressionDumper.Core" Version="1.5.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="pauldeen79.ClassFramework.TemplateFramework" Version="0.10.0" />
-    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Builders" Version="0.6.3" />
-    <PackageReference Include="pauldeen79.ExpressionFramework.Domain.Specialized" Version="0.6.3" />
+    <PackageReference Include="pauldeen79.ExpressionFramework.Domain" Version="0.7.1" />
     <PackageReference Include="pauldeen79.TemplateFramework.Core.CodeGeneration" Version="0.9.3" />
   </ItemGroup>
 

--- a/src/QueryFramework.Core.Tests/ComposableEvaluatableBuilderWrapperTests.cs
+++ b/src/QueryFramework.Core.Tests/ComposableEvaluatableBuilderWrapperTests.cs
@@ -3,24 +3,44 @@
 public class ComposableEvaluatableBuilderWrapperTests
 {
     [Fact]
-    public void Can_Create_QueryCondition_Using_DoesContain()
+    public void Can_Create_QueryCondition_Using_DoesContain_Constant_Value()
         => QueryConditionTest(x => x.Contains("value"), typeof(StringContainsOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_DoesEndWith()
+    public void Can_Create_QueryCondition_Using_DoesContain_Expression()
+        => QueryConditionTest(x => x.Contains(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(StringContainsOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_DoesEndWith_Constant_Value()
         => QueryConditionTest(x => x.EndsWith("value"), typeof(EndsWithOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsEqualTo()
+    public void Can_Create_QueryCondition_Using_DoesEndWith_Expression()
+        => QueryConditionTest(x => x.EndsWith(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(EndsWithOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsEqualTo_Constant_Value()
         => QueryConditionTest(x => x.IsEqualTo("value"), typeof(EqualsOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsGreaterOrEqualThan()
+    public void Can_Create_QueryCondition_Using_IsEqualTo_Expression()
+        => QueryConditionTest(x => x.IsEqualTo(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(EqualsOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsGreaterOrEqualThan_Constant_Value()
         => QueryConditionTest(x => x.IsGreaterOrEqualThan("value"), typeof(IsGreaterOrEqualOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsGreaterThan()
+    public void Can_Create_QueryCondition_Using_IsGreaterOrEqualThan_Expression()
+        => QueryConditionTest(x => x.IsGreaterOrEqualThan(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(IsGreaterOrEqualOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsGreaterThan_Constant_Value()
         => QueryConditionTest(x => x.IsGreaterThan("value"), typeof(IsGreaterOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsGreaterThan_Expression()
+        => QueryConditionTest(x => x.IsGreaterThan(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(IsGreaterOperator));
 
     [Fact]
     public void Can_Create_QueryCondition_Using_IsNotNullOrEmpty()
@@ -47,32 +67,60 @@ public class ComposableEvaluatableBuilderWrapperTests
         => QueryConditionTest(x => x.IsNull(), typeof(IsNullOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsSmallerOrEqualThan()
+    public void Can_Create_QueryCondition_Using_IsSmallerOrEqualThan_Constant_Value()
         => QueryConditionTest(x => x.IsSmallerOrEqualThan("value"), typeof(IsSmallerOrEqualOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsSmallerThan()
+    public void Can_Create_QueryCondition_Using_IsSmallerOrEqualThan_Expression()
+        => QueryConditionTest(x => x.IsSmallerOrEqualThan(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(IsSmallerOrEqualOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsSmallerThan_Constant_Value()
         => QueryConditionTest(x => x.IsSmallerThan("value"), typeof(IsSmallerOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_DoesNotContain()
+    public void Can_Create_QueryCondition_Using_IsSmallerThan_Expression()
+        => QueryConditionTest(x => x.IsSmallerThan(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(IsSmallerOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_DoesNotContain_Constant_Value()
         => QueryConditionTest(x => x.DoesNotContain("value"), typeof(StringNotContainsOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_DoesNotEndWith()
+    public void Can_Create_QueryCondition_Using_DoesNotContain_Expression()
+        => QueryConditionTest(x => x.DoesNotContain(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(StringNotContainsOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_DoesNotEndWith_Constant_Value()
         => QueryConditionTest(x => x.DoesNotEndWith("value"), typeof(NotEndsWithOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsNotEqualTo()
+    public void Can_Create_QueryCondition_Using_DoesNotEndWith_Expression()
+        => QueryConditionTest(x => x.DoesNotEndWith(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(NotEndsWithOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsNotEqualTo_Constant_Value()
         => QueryConditionTest(x => x.IsNotEqualTo("value"), typeof(NotEqualsOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_DoesNotStartWith()
+    public void Can_Create_QueryCondition_Using_IsNotEqualTo_Expression()
+        => QueryConditionTest(x => x.IsNotEqualTo(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(NotEqualsOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_DoesNotStartWith_Constant_Value()
         => QueryConditionTest(x => x.DoesNotStartWith("value"), typeof(NotStartsWithOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_DoesStartWith()
+    public void Can_Create_QueryCondition_Using_DoesNotStartWith_Expression()
+        => QueryConditionTest(x => x.DoesNotStartWith(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(NotStartsWithOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_DoesStartWith_Constant_Value()
         => QueryConditionTest(x => x.StartsWith("value"), typeof(StartsWithOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_DoesStartWith_Expression()
+        => QueryConditionTest(x => x.StartsWith(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(StartsWithOperator));
 
     private static void QueryConditionTest(Func<ComposableEvaluatableBuilderWrapper<SingleEntityQueryBuilder>, SingleEntityQueryBuilder> func, Type expectedOperatorType)
     {
@@ -88,7 +136,8 @@ public class ComposableEvaluatableBuilderWrapperTests
         var rightExpression = actual.RightExpression;
         var @operator = actual.Operator;
         var field = leftExpression as FieldExpressionBuilder;
-        var value = (rightExpression as ConstantExpressionBuilder)?.Value;
+        var value = (rightExpression as ConstantExpressionBuilder)?.Value
+            ?? (rightExpression as TypedConstantExpressionBuilder<string>)?.Value;
         ((TypedConstantExpressionBuilder<string>)field!.FieldNameExpression).Value.Should().Be("fieldname");
         if (expectedOperatorType == typeof(IsNullOperator)
             || expectedOperatorType == typeof(IsNullOrEmptyOperator)

--- a/src/QueryFramework.Core.Tests/Extensions/QueryBuilderExtensionsTests.cs
+++ b/src/QueryFramework.Core.Tests/Extensions/QueryBuilderExtensionsTests.cs
@@ -39,16 +39,20 @@ public class QueryBuilderExtensionsTests
         var actual = sut.OrderBy("Field1", "Field2", "Field3");
 
         // Assert
-        actual.OrderByFields.Should().HaveCount(3);
-        var field0 = actual.OrderByFields[0].FieldNameExpression.Build().GetFieldName();
-        var field1 = actual.OrderByFields[1].FieldNameExpression.Build().GetFieldName();
-        var field2 = actual.OrderByFields[2].FieldNameExpression.Build().GetFieldName();
-        field0.ToString().Should().Be("Field1");
-        actual.OrderByFields[0].Order.Should().Be(QuerySortOrderDirection.Ascending);
-        field1.ToString().Should().Be("Field2");
-        actual.OrderByFields[1].Order.Should().Be(QuerySortOrderDirection.Ascending);
-        field2.ToString().Should().Be("Field3");
-        actual.OrderByFields[2].Order.Should().Be(QuerySortOrderDirection.Ascending);
+        AssertOrderBy(actual);
+    }
+
+    [Fact]
+    public void Can_Use_Result_Of_OrderBy_To_Convert_To_Entity_And_Back_To_Builder()
+    {
+        // Arrange
+        var sut = new SingleEntityQueryBuilder();
+
+        // Act
+        var actual = sut.OrderBy("Field1", "Field2", "Field3").BuildTyped().ToTypedBuilder();
+
+        // Assert
+        AssertOrderBy(actual);
     }
 
     [Fact]
@@ -204,5 +208,19 @@ public class QueryBuilderExtensionsTests
         ((TypedConstantExpressionBuilder<string>)field!.FieldNameExpression).Value.Should().Be("field");
         firstCondition.Operator.Should().BeOfType<IsNullOperatorBuilder>();
         firstCondition.RightExpression.Should().BeOfType<EmptyExpressionBuilder>();
+    }
+
+    private static void AssertOrderBy(SingleEntityQueryBuilder actual)
+    {
+        actual.OrderByFields.Should().HaveCount(3);
+        var field0 = actual.OrderByFields[0].FieldNameExpression.Build().GetFieldName();
+        var field1 = actual.OrderByFields[1].FieldNameExpression.Build().GetFieldName();
+        var field2 = actual.OrderByFields[2].FieldNameExpression.Build().GetFieldName();
+        field0.ToString().Should().Be("Field1");
+        actual.OrderByFields[0].Order.Should().Be(QuerySortOrderDirection.Ascending);
+        field1.ToString().Should().Be("Field2");
+        actual.OrderByFields[1].Order.Should().Be(QuerySortOrderDirection.Ascending);
+        field2.ToString().Should().Be("Field3");
+        actual.OrderByFields[2].Order.Should().Be(QuerySortOrderDirection.Ascending);
     }
 }

--- a/src/QueryFramework.Core.Tests/Extensions/QueryConditionExtensionsTests.cs
+++ b/src/QueryFramework.Core.Tests/Extensions/QueryConditionExtensionsTests.cs
@@ -3,24 +3,44 @@
 public class QueryConditionExtensionsTests
 {
     [Fact]
-    public void Can_Create_QueryCondition_Using_Contains()
+    public void Can_Create_QueryCondition_Using_Contains_Constant_Value()
         => AssertQueryCondition(x => x.Contains("value"), typeof(StringContainsOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_EndsWith()
+    public void Can_Create_QueryCondition_Using_Contains_Expression()
+        => AssertQueryCondition(x => x.Contains(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(StringContainsOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_EndsWith_Constant_Value()
         => AssertQueryCondition(x => x.EndsWith("value"), typeof(EndsWithOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsEqualTo()
+    public void Can_Create_QueryCondition_Using_EndsWith_Expression()
+        => AssertQueryCondition(x => x.EndsWith(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(EndsWithOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsEqualTo_Constant_Value()
         => AssertQueryCondition(x => x.IsEqualTo("value"), typeof(EqualsOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsGreaterOrEqualThan()
+    public void Can_Create_QueryCondition_Using_IsEqualTo_Expression()
+        => AssertQueryCondition(x => x.IsEqualTo(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(EqualsOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsGreaterOrEqualThan_Constant_Value()
         => AssertQueryCondition(x => x.IsGreaterOrEqualThan("value"), typeof(IsGreaterOrEqualOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsGreaterThan()
+    public void Can_Create_QueryCondition_Using_IsGreaterOrEqualThan_Expression()
+        => AssertQueryCondition(x => x.IsGreaterOrEqualThan(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(IsGreaterOrEqualOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsGreaterThan_Constant_Value()
         => AssertQueryCondition(x => x.IsGreaterThan("value"), typeof(IsGreaterOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsGreaterThan_Expression()
+        => AssertQueryCondition(x => x.IsGreaterThan(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(IsGreaterOperator));
 
     [Fact]
     public void Can_Create_QueryCondition_Using_IsNotNullOrEmpty()
@@ -47,32 +67,60 @@ public class QueryConditionExtensionsTests
         => AssertQueryCondition(x => x.IsNull(), typeof(IsNullOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsSmallerOrEqualThan()
+    public void Can_Create_QueryCondition_Using_IsSmallerOrEqualThan_Constant_Value()
         => AssertQueryCondition(x => x.IsSmallerOrEqualThan("value"), typeof(IsSmallerOrEqualOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsSmallerThan()
+    public void Can_Create_QueryCondition_Using_IsSmallerOrEqualThan_Expression()
+        => AssertQueryCondition(x => x.IsSmallerOrEqualThan(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(IsSmallerOrEqualOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsSmallerThan_Constant_Value()
         => AssertQueryCondition(x => x.IsSmallerThan("value"), typeof(IsSmallerOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_DoesNotContain()
+    public void Can_Create_QueryCondition_Using_IsSmallerThan_Expression()
+        => AssertQueryCondition(x => x.IsSmallerThan(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(IsSmallerOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_DoesNotContain_Constant_Value()
         => AssertQueryCondition(x => x.DoesNotContain("value"), typeof(StringNotContainsOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_DoesNotEndWith()
+    public void Can_Create_QueryCondition_Using_DoesNotContain_Expression()
+        => AssertQueryCondition(x => x.DoesNotContain(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(StringNotContainsOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_DoesNotEndWith_Constant_Value()
         => AssertQueryCondition(x => x.DoesNotEndWith("value"), typeof(NotEndsWithOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_IsNotEqualTo()
+    public void Can_Create_QueryCondition_Using_DoesNotEndWith_Expression()
+        => AssertQueryCondition(x => x.DoesNotEndWith(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(NotEndsWithOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_IsNotEqualTo_Constant_Value()
         => AssertQueryCondition(x => x.IsNotEqualTo("value"), typeof(NotEqualsOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_DoesNotStartWith()
+    public void Can_Create_QueryCondition_Using_IsNotEqualTo_Expression()
+        => AssertQueryCondition(x => x.IsNotEqualTo(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(NotEqualsOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_DoesNotStartWith_Constant_Value()
         => AssertQueryCondition(x => x.DoesNotStartWith("value"), typeof(NotStartsWithOperator));
 
     [Fact]
-    public void Can_Create_QueryCondition_Using_StartsWith()
+    public void Can_Create_QueryCondition_Using_DoesNotStartWith_Expression()
+        => AssertQueryCondition(x => x.DoesNotStartWith(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(NotStartsWithOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_StartsWith_Constant_Value()
         => AssertQueryCondition(x => x.StartsWith("value"), typeof(StartsWithOperator));
+
+    [Fact]
+    public void Can_Create_QueryCondition_Using_StartsWith_Expression()
+        => AssertQueryCondition(x => x.StartsWith(new TypedConstantExpressionBuilder<string>().WithValue("value")), typeof(StartsWithOperator));
 
     private static void AssertQueryCondition(Func<ExpressionBuilder, ComposableEvaluatableBuilder> func, Type expectedOperatorType)
     {
@@ -87,7 +135,8 @@ public class QueryConditionExtensionsTests
         var rightExpression = actual.RightExpression;
         var @operator = actual.Operator;
         var field = leftExpression as FieldExpressionBuilder;
-        var value = (rightExpression as ConstantExpressionBuilder)?.Value;
+        var value = (rightExpression as ConstantExpressionBuilder)?.Value
+            ?? (rightExpression as TypedConstantExpressionBuilder<string>)?.Value;
         ((TypedConstantExpressionBuilder<string>)field!.FieldNameExpression).Value.Should().Be("fieldName");
         if (expectedOperatorType == typeof(IsNullOperator)
             || expectedOperatorType == typeof(IsNullOrEmptyOperator)

--- a/src/QueryFramework.Core.Tests/Queries/Builders/FieldSelectionQueryBuilderTests.cs
+++ b/src/QueryFramework.Core.Tests/Queries/Builders/FieldSelectionQueryBuilderTests.cs
@@ -36,7 +36,7 @@ public class FieldSelectionQueryBuilderTests
         var sut = new FieldSelectionQueryBuilder
         {
             Filter = new ComposedEvaluatableBuilder().AddConditions(conditions),
-            OrderByFields = orderByFields.Cast<IQuerySortOrderBuilder>().ToList(),
+            OrderByFields = orderByFields.ToList(),
             Limit = limit,
             Offset = offset,
             Distinct = distinct,
@@ -70,7 +70,7 @@ public class FieldSelectionQueryBuilderTests
         var sut = new FieldSelectionQueryBuilder
         {
             Filter = new ComposedEvaluatableBuilder().AddConditions(conditions),
-            OrderByFields = orderByFields.Cast<IQuerySortOrderBuilder>().ToList(),
+            OrderByFields = orderByFields.ToList(),
             Limit = limit,
             Offset = offset,
             Distinct = distinct,
@@ -87,7 +87,7 @@ public class FieldSelectionQueryBuilderTests
         actual.GetAllFields.Should().Be(sut.GetAllFields);
         actual.Limit.Should().Be(sut.Limit);
         actual.Offset.Should().Be(sut.Offset);
-        actual.Filter.Conditions.Should().HaveCount(sut.Filter.Conditions.Count());
+        actual.Filter.Conditions.Should().HaveCount(sut.Filter.Conditions.Count);
         actual.FieldNames.Should().HaveCount(sut.FieldNames.Count);
         actual.OrderByFields.Should().HaveCount(sut.OrderByFields.Count);
     }

--- a/src/QueryFramework.Core.Tests/Queries/Builders/GroupingQueryBuilderTests.cs
+++ b/src/QueryFramework.Core.Tests/Queries/Builders/GroupingQueryBuilderTests.cs
@@ -33,7 +33,7 @@ public class GroupingQueryBuilderTests
         var sut = new GroupingQueryBuilder
         {
             Filter = new ComposedEvaluatableBuilder().AddConditions(conditions),
-            OrderByFields = orderByFields.Cast<IQuerySortOrderBuilder>().ToList(),
+            OrderByFields = orderByFields.ToList(),
             Limit = limit,
             Offset = offset,
             GroupByFields = groupByFields.Cast<ExpressionBuilder>().ToList(),
@@ -63,7 +63,7 @@ public class GroupingQueryBuilderTests
         var sut = new GroupingQueryBuilder
         {
             Filter = new ComposedEvaluatableBuilder().AddConditions(conditions),
-            OrderByFields = orderByFields.Cast<IQuerySortOrderBuilder>().ToList(),
+            OrderByFields = orderByFields.ToList(),
             Limit = limit,
             Offset = offset,
             GroupByFields = groupByFields.Cast<ExpressionBuilder>().ToList(),
@@ -77,7 +77,7 @@ public class GroupingQueryBuilderTests
         actual.Should().NotBeNull();
         actual.Limit.Should().Be(sut.Limit);
         actual.Offset.Should().Be(sut.Offset);
-        actual.Filter.Conditions.Should().HaveCount(sut.Filter.Conditions.Count());
+        actual.Filter.Conditions.Should().HaveCount(sut.Filter.Conditions.Count);
         actual.OrderByFields.Should().HaveCount(sut.OrderByFields.Count);
         actual.GroupByFields.Should().HaveCount(1);
         actual.GroupByFilter.Conditions.Should().HaveCount(1);

--- a/src/QueryFramework.Core.Tests/Queries/Builders/SingleEntityQueryBuilderTests.cs
+++ b/src/QueryFramework.Core.Tests/Queries/Builders/SingleEntityQueryBuilderTests.cs
@@ -30,7 +30,7 @@ public class SingleEntityQueryBuilderTests
         var sut = new SingleEntityQueryBuilder
         {
             Filter = new ComposedEvaluatableBuilder().AddConditions(conditions),
-            OrderByFields = orderByFields.Cast<IQuerySortOrderBuilder>().ToList(),
+            OrderByFields = orderByFields.ToList(),
             Limit = limit,
             Offset = offset
         };
@@ -55,7 +55,7 @@ public class SingleEntityQueryBuilderTests
         var sut = new SingleEntityQueryBuilder
         {
             Filter = new ComposedEvaluatableBuilder().AddConditions(conditions),
-            OrderByFields = orderByFields.Cast<IQuerySortOrderBuilder>().ToList(),
+            OrderByFields = orderByFields.ToList(),
             Limit = limit,
             Offset = offset
         };
@@ -67,7 +67,7 @@ public class SingleEntityQueryBuilderTests
         actual.Should().NotBeNull();
         actual.Limit.Should().Be(sut.Limit);
         actual.Offset.Should().Be(sut.Offset);
-        actual.Filter.Conditions.Should().HaveCount(sut.Filter.Conditions.Count());
+        actual.Filter.Conditions.Should().HaveCount(sut.Filter.Conditions.Count);
         actual.OrderByFields.Should().HaveCount(sut.OrderByFields.Count);
     }
 }

--- a/src/QueryFramework.InMemory.Tests/QueryProcessorTests.cs
+++ b/src/QueryFramework.InMemory.Tests/QueryProcessorTests.cs
@@ -687,6 +687,11 @@ public sealed class QueryProcessorTests : IDisposable
 
     public sealed record UnsupportedOperator : Operator
     {
+        public override OperatorBuilder ToBuilder()
+        {
+            throw new NotImplementedException();
+        }
+
         protected override Result<bool> Evaluate(object? leftValue, object? rightValue)
         {
             throw new NotImplementedException();

--- a/src/QueryFramework.SqlServer.Tests/Extensions/OperatorExtensionsTests.cs
+++ b/src/QueryFramework.SqlServer.Tests/Extensions/OperatorExtensionsTests.cs
@@ -81,6 +81,11 @@ public class OperatorExtensionsTests
         {
         }
 
+        public override OperatorBuilder ToBuilder()
+        {
+            throw new NotImplementedException();
+        }
+
         protected override Result<bool> Evaluate(object? leftValue, object? rightValue)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
- Upgraded package references to latest version
- Narrowed string arguments from object? to string (i.e. contains, starts with, ends with) and added convenience overloads to work with expressionbuilders instead of (constant) values